### PR TITLE
fix: Uptime displays correctly

### DIFF
--- a/lua/dashgate/dashboard.lua
+++ b/lua/dashgate/dashboard.lua
@@ -2,6 +2,24 @@ local os = require("dashgate.os")
 local ascii_art = require("dashgate.ascii-art")
 
 local M = {}
+
+function M.format_uptime(uptime)
+  local parts = {}
+  if uptime.days > 0 then
+    table.insert(parts, uptime.days .. "d")
+  end
+  if uptime.hours > 0 then
+    table.insert(parts, uptime.hours .. "h")
+  end
+  if uptime.mins > 0 then
+    table.insert(parts, uptime.mins .. "m")
+  end
+  if #parts == 0 then
+    return "< 1m"
+  end
+  return table.concat(parts, " ")
+end
+
 -- Create the dashboard buffer
 function M.create_dashboard_buffer()
   local buf = vim.api.nvim_create_buf(false, true)
@@ -31,7 +49,7 @@ function M.render_dashboard(buf)
     string.format("│ Host: %s", sys_info.hostname),
     string.format("│ Kernel: %s", sys_info.kernel),
     string.format("│ Arch: %s", sys_info.arch),
-    string.format("│ Uptime: %s", sys_info.uptime:sub(1, 20)),
+    string.format("│ Uptime: %s", M.format_uptime(sys_info.uptime)),
   }
 
   if sys_info.memory then

--- a/lua/dashgate/init.lua
+++ b/lua/dashgate/init.lua
@@ -11,12 +11,12 @@ local plugin_state = {
 }
 
 local dashboard_window_options = {
-  { option = "number",         value = false },
+  { option = "number", value = false },
   { option = "relativenumber", value = false },
-  { option = "cursorline",     value = false },
-  { option = "cursorcolumn",   value = false },
-  { option = "foldcolumn",     value = "0" },
-  { option = "signcolumn",     value = "no" },
+  { option = "cursorline", value = false },
+  { option = "cursorcolumn", value = false },
+  { option = "foldcolumn", value = "0" },
+  { option = "signcolumn", value = "no" },
 }
 
 -- Set up dashboard keymaps
@@ -54,7 +54,7 @@ local function enable_plugin()
     -- Loop over all the window options the dashboard sets, retrieve them for the current window and save them for later
     for index, window_option in ipairs(dashboard_window_options) do
       plugin_state.original_window_options[index] =
-      { option = window_option.option, value = vim.api.nvim_get_option_value(window_option.option, {}) }
+        { option = window_option.option, value = vim.api.nvim_get_option_value(window_option.option, {}) }
     end
   end
 end

--- a/lua/dashgate/os.lua
+++ b/lua/dashgate/os.lua
@@ -26,6 +26,39 @@ function M.get_os()
   end
 end
 
+-- Parse uptime string into { days, hours, mins }
+function M.parse_uptime(uptime_str)
+  local result = { days = 0, hours = 0, mins = 0 }
+
+  -- Strip everything from "user" or "load" onward
+  local relevant = uptime_str:match("up%s+(.-)%s*%d+%s*user") or uptime_str:match("up%s+(.+)") or uptime_str
+
+  -- Extract days
+  local days = relevant:match("(%d+)%s*days?")
+  if days then
+    result.days = tonumber(days)
+  end
+
+  -- Extract HH:MM format (macOS/BSD style)
+  local hh, mm = relevant:match("(%d+):(%d+)")
+  if hh then
+    result.hours = tonumber(hh)
+    result.mins = tonumber(mm)
+  end
+
+  -- Extract spelled-out hours/minutes (Linux uptime -p style)
+  local hours = relevant:match("(%d+)%s*hours?")
+  if hours then
+    result.hours = tonumber(hours)
+  end
+  local mins = relevant:match("(%d+)%s*min")
+  if mins then
+    result.mins = tonumber(mins)
+  end
+
+  return result
+end
+
 -- Get system information
 function M.get_system_info()
   local info = {}
@@ -41,15 +74,15 @@ function M.get_system_info()
   if uptime_handle then
     local uptime_str = uptime_handle:read("*a"):gsub("\n", "")
     uptime_handle:close()
-    info.uptime = uptime_str:match("up (.+)") or uptime_str
+    info.uptime = M.parse_uptime(uptime_str)
   else
-    info.uptime = "unknown"
+    info.uptime = { days = 0, hours = 0, mins = 0 }
   end
 
   -- Get memory info (Linux/macOS)
   if info.os ~= "windows" then
     local mem_handle =
-        io.popen("free -h 2>/dev/null | awk '/^Mem:/ {print $3\"/\"$2}' || vm_stat 2>/dev/null | head -4")
+      io.popen("free -h 2>/dev/null | awk '/^Mem:/ {print $3\"/\"$2}' || vm_stat 2>/dev/null | head -4")
     if mem_handle then
       info.memory = mem_handle:read("*a"):gsub("\n", "") or "unknown"
       mem_handle:close()


### PR DESCRIPTION
This pull request improves how system uptime is parsed and displayed in the dashboard by introducing structured parsing and formatting, replacing the previous approach of using raw uptime strings. The changes ensure that uptime is shown in a consistent and user-friendly format regardless of platform differences.

**Uptime parsing and formatting improvements:**

* Added a new function `parse_uptime` in `os.lua` to extract days, hours, and minutes from various uptime string formats, supporting different OS outputs.
* Updated `get_system_info` in `os.lua` to use the structured uptime object from `parse_uptime`, and default to `{ days = 0, hours = 0, mins = 0 }` if unavailable.

**Dashboard display enhancements:**

* Added a `format_uptime` function in `dashboard.lua` to convert the structured uptime object into a concise human-readable string (e.g., "2d 3h 15m" or "< 1m").
* Modified the dashboard rendering to use the new `format_uptime` output instead of slicing the raw uptime string, ensuring consistent and clear display.