### PR TITLE
fix: Dashboard is callable again

### DIFF
--- a/lua/dashgate/init.lua
+++ b/lua/dashgate/init.lua
@@ -62,6 +62,11 @@ local function enable_plugin()
 end
 
 local function cleanup_plugin(event)
+  -- Don't clean up when the dashboard buffer itself is entering the window
+  if event and event.buf == plugin_state.dashboard_buf then
+    return
+  end
+
   local win_id = vim.api.nvim_get_current_win()
   -- local is_buf_visible =  winId == -1 or
   if win_id == plugin_state.window_buf then


### PR DESCRIPTION
This pull request introduces a safeguard to the plugin's cleanup logic to prevent accidental cleanup when the dashboard buffer is being activated. This ensures the dashboard remains stable and is not inadvertently closed or reset when it gains focus.

- **Plugin stability improvement:**
  * Updated `cleanup_plugin` in `lua/dashgate/init.lua` to skip cleanup if the dashboard buffer is entering the window, preventing unwanted cleanup actions when the dashboard is shown.